### PR TITLE
Add error checking for older version of scripts and creation of organization relationships.

### DIFF
--- a/SetupCrossTenantRelationshipForTargetTenant.ps1
+++ b/SetupCrossTenantRelationshipForTargetTenant.ps1
@@ -803,15 +803,16 @@ function Verification {
         Exit
     }
     Write-Host "`nVerifying that your script is up to date with the latest changes."
-    Write-Host "`nBeginning download of SetupCrossTenantRelationshipForTargetTenant.ps1 and creation of temporary folder."
+    Write-Host "`nBeginning download of SetupCrossTenantRelationshipForTargetTenant.ps1 and creation of temporary files."
     if ((Test-Path -Path .\XTenantTemp) -eq $true) {
         Remove-Item -Path .\XTenantTemp\ -Recurse -Force | Out-Null
     }
     New-Item -Path . -Name XTenantTemp -ItemType Directory | Out-Null
     Invoke-WebRequest -Uri https://github.com/microsoft/cross-tenant/releases/download/Preview/SetupCrossTenantRelationshipForTargetTenant.ps1 -Outfile .\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1
     if ((Get-FileHash .\SetupCrossTenantRelationshipForTargetTenant.ps1).hash -eq (Get-FileHash .\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {
-        Write-Host "`nYou are using the latest version of the script. Proceeding with setup."
+        Write-Host "`nYou are using the latest version of the script. Removing temporary files and proceeding with setup."
         Start-Sleep 1
+        Remove-Item -Path .\XTenantTemp\ -Recurse -Force | Out-Null
         Main
     }
     elseif ((Get-FileHash .\SetupCrossTenantRelationshipForTargetTenant.ps1).hash -ne (Get-FileHash .\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {

--- a/SetupCrossTenantRelationshipForTargetTenant.ps1
+++ b/SetupCrossTenantRelationshipForTargetTenant.ps1
@@ -822,7 +822,7 @@ function Verification {
         Start-Sleep 1
         Write-Host "`nReplacing the local copy of SetupCrossTenantRelationshipForTargetTenant.ps1 and cleaning up temporary files..."
         Start-Sleep 1
-        Copy-Item $ScriptDir\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1 -Destination . | Out-Null
+        Copy-Item $ScriptDir\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1 -Destination $ScriptDir | Out-Null
         Start-Sleep 1
         Remove-Item -Path $ScriptDir\XTenantTemp\ -Recurse -Force | Out-Null
         Write-Host "Update completed. You will need to run the script again."

--- a/SetupCrossTenantRelationshipForTargetTenant.ps1
+++ b/SetupCrossTenantRelationshipForTargetTenant.ps1
@@ -793,7 +793,8 @@ function PreValidation() {
 }
 
 function Verification {
-    Write-Host "`nBeginning verification steps."
+    Write-Host "`nBeginning verification steps."`n
+    Write-Host "Verifying ability to create a new organization relationship in the tenant."
     try {
         New-OrganizationRelationship -DomainNames contoso.onmicrosoft.com -Name Contoso -WhatIf -ErrorAction Stop
     }
@@ -801,6 +802,7 @@ function Verification {
         Write-Output "You need to run the command Enable-OrganizationCustomization before continuing with execution of the script."
         Exit
     }
+    Write-Host "`nVerifying that your script is up to date with the latest changes."
     if ((Test-Path -Path .\XTenantTemp) -eq $true) {
         Remove-Item -Path .\XTenantTemp\ -Recurse -Force | Out-Null
     }

--- a/SetupCrossTenantRelationshipForTargetTenant.ps1
+++ b/SetupCrossTenantRelationshipForTargetTenant.ps1
@@ -186,6 +186,7 @@ param
 
 $ErrorActionPreference = 'Stop'
 
+$ScriptPath = $MyInvocation.MyCommand.Path
 $MS_GRAPH_APP_ID = "00000003-0000-0000-c000-000000000000"
 $MS_GRAPH_APP_ROLE = "User.Invite.All"
 $EXO_APP_ID = "00000002-0000-0ff1-ce00-000000000000"
@@ -780,7 +781,7 @@ function PreValidation() {
     Write-Host "`nWe are verifying that you are using the latest version of the script."`n
     Write-Host "This requires that we download the latest version of the script from GitHub to compare with your local copy."
     Write-Host "This file will be stored on your local computer temporarily, as well as overwrite your existing script file if it is out of date."
-    $title = "Confirm: Allow for download from GitHub and that you are running the script from the local directory the script exists in."
+    $title = "Confirm: Allow for download from GitHub."
     $message = "`nIf you are ready to begin this step, select 'Y'. `nIf you would prefer to manually download the scripts to make sure you have the latest version or change your path, select 'N'"
     $yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", "Yes"
     $no = New-Object System.Management.Automation.Host.ChoiceDescription "&No", "No"
@@ -804,25 +805,25 @@ function Verification {
     }
     Write-Host "`nVerifying that your script is up to date with the latest changes."
     Write-Host "`nBeginning download of SetupCrossTenantRelationshipForTargetTenant.ps1 and creation of temporary files."
-    if ((Test-Path -Path .\XTenantTemp) -eq $true) {
-        Remove-Item -Path .\XTenantTemp\ -Recurse -Force | Out-Null
+    if ((Test-Path -Path $ScriptPath\XTenantTemp) -eq $true) {
+        Remove-Item -Path $ScriptPath\XTenantTemp\ -Recurse -Force | Out-Null
     }
     New-Item -Path . -Name XTenantTemp -ItemType Directory | Out-Null
-    Invoke-WebRequest -Uri https://github.com/microsoft/cross-tenant/releases/download/Preview/SetupCrossTenantRelationshipForTargetTenant.ps1 -Outfile .\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1
-    if ((Get-FileHash .\SetupCrossTenantRelationshipForTargetTenant.ps1).hash -eq (Get-FileHash .\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {
+    Invoke-WebRequest -Uri https://github.com/microsoft/cross-tenant/releases/download/Preview/SetupCrossTenantRelationshipForTargetTenant.ps1 -Outfile $ScriptPath\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1
+    if ((Get-FileHash $ScriptPath\SetupCrossTenantRelationshipForTargetTenant.ps1).hash -eq (Get-FileHash $ScriptPath\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {
         Write-Host "`nYou are using the latest version of the script. Removing temporary files and proceeding with setup."
         Start-Sleep 1
-        Remove-Item -Path .\XTenantTemp\ -Recurse -Force | Out-Null
+        Remove-Item -Path $ScriptPath\XTenantTemp\ -Recurse -Force | Out-Null
         Main
     }
-    elseif ((Get-FileHash .\SetupCrossTenantRelationshipForTargetTenant.ps1).hash -ne (Get-FileHash .\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {
+    elseif ((Get-FileHash $ScriptPath\SetupCrossTenantRelationshipForTargetTenant.ps1).hash -ne (Get-FileHash $ScriptPath\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {
         Write-Host "`nYou are not using the latest version of the script."`n
         Start-Sleep 1
         Write-Host "`nReplacing the local copy of SetupCrossTenantRelationshipForTargetTenant.ps1 and cleaning up temporary files..."
         Start-Sleep 1
-        Copy-Item .\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1 -Destination . | Out-Null
+        Copy-Item $ScriptPath\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1 -Destination . | Out-Null
         Start-Sleep 1
-        Remove-Item -Path .\XTenantTemp\ -Recurse -Force | Out-Null
+        Remove-Item -Path $ScriptPath\XTenantTemp\ -Recurse -Force | Out-Null
         Write-Host "Update completed. You will need to run the script again."
         Start-Sleep 1
         Exit

--- a/SetupCrossTenantRelationshipForTargetTenant.ps1
+++ b/SetupCrossTenantRelationshipForTargetTenant.ps1
@@ -803,6 +803,7 @@ function Verification {
         Exit
     }
     Write-Host "`nVerifying that your script is up to date with the latest changes."
+    Write-Host "`nBeginning download of SetupCrossTenantRelationshipForTargetTenant.ps1 and creation of temporary folder."
     if ((Test-Path -Path .\XTenantTemp) -eq $true) {
         Remove-Item -Path .\XTenantTemp\ -Recurse -Force | Out-Null
     }
@@ -815,9 +816,7 @@ function Verification {
     }
     elseif ((Get-FileHash .\SetupCrossTenantRelationshipForTargetTenant.ps1).hash -ne (Get-FileHash .\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {
         Write-Host "`nYou are not using the latest version of the script."`n
-        Write-Host "We are replacing the local version with the most current version available on GitHub."`n
         Start-Sleep 1
-        Write-Host "`nBeginning download of SetupCrossTenantRelationshipForTargetTenant.ps1"
         Write-Host "`nReplacing the local copy of SetupCrossTenantRelationshipForTargetTenant.ps1 and cleaning up temporary files..."
         Start-Sleep 1
         Copy-Item .\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1 -Destination . | Out-Null

--- a/SetupCrossTenantRelationshipForTargetTenant.ps1
+++ b/SetupCrossTenantRelationshipForTargetTenant.ps1
@@ -187,6 +187,7 @@ param
 $ErrorActionPreference = 'Stop'
 
 $ScriptPath = $MyInvocation.MyCommand.Path
+$ScriptDir = Split-Path $ScriptPath
 $MS_GRAPH_APP_ID = "00000003-0000-0000-c000-000000000000"
 $MS_GRAPH_APP_ROLE = "User.Invite.All"
 $EXO_APP_ID = "00000002-0000-0ff1-ce00-000000000000"
@@ -805,25 +806,25 @@ function Verification {
     }
     Write-Host "`nVerifying that your script is up to date with the latest changes."
     Write-Host "`nBeginning download of SetupCrossTenantRelationshipForTargetTenant.ps1 and creation of temporary files."
-    if ((Test-Path -Path $ScriptPath\XTenantTemp) -eq $true) {
-        Remove-Item -Path $ScriptPath\XTenantTemp\ -Recurse -Force | Out-Null
+    if ((Test-Path -Path $ScriptDir\XTenantTemp) -eq $true) {
+        Remove-Item -Path $ScriptDir\XTenantTemp\ -Recurse -Force | Out-Null
     }
     New-Item -Path . -Name XTenantTemp -ItemType Directory | Out-Null
-    Invoke-WebRequest -Uri https://github.com/microsoft/cross-tenant/releases/download/Preview/SetupCrossTenantRelationshipForTargetTenant.ps1 -Outfile $ScriptPath\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1
-    if ((Get-FileHash $ScriptPath\SetupCrossTenantRelationshipForTargetTenant.ps1).hash -eq (Get-FileHash $ScriptPath\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {
+    Invoke-WebRequest -Uri https://github.com/microsoft/cross-tenant/releases/download/Preview/SetupCrossTenantRelationshipForTargetTenant.ps1 -Outfile $ScriptDir\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1
+    if ((Get-FileHash $ScriptDir\SetupCrossTenantRelationshipForTargetTenant.ps1).hash -eq (Get-FileHash $ScriptDir\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {
         Write-Host "`nYou are using the latest version of the script. Removing temporary files and proceeding with setup."
         Start-Sleep 1
-        Remove-Item -Path $ScriptPath\XTenantTemp\ -Recurse -Force | Out-Null
+        Remove-Item -Path $ScriptDir\XTenantTemp\ -Recurse -Force | Out-Null
         Main
     }
-    elseif ((Get-FileHash $ScriptPath\SetupCrossTenantRelationshipForTargetTenant.ps1).hash -ne (Get-FileHash $ScriptPath\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {
+    elseif ((Get-FileHash $ScriptDir).hash -ne (Get-FileHash $ScriptDir\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {
         Write-Host "`nYou are not using the latest version of the script."`n
         Start-Sleep 1
         Write-Host "`nReplacing the local copy of SetupCrossTenantRelationshipForTargetTenant.ps1 and cleaning up temporary files..."
         Start-Sleep 1
-        Copy-Item $ScriptPath\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1 -Destination . | Out-Null
+        Copy-Item $ScriptDir\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1 -Destination . | Out-Null
         Start-Sleep 1
-        Remove-Item -Path $ScriptPath\XTenantTemp\ -Recurse -Force | Out-Null
+        Remove-Item -Path $ScriptDir\XTenantTemp\ -Recurse -Force | Out-Null
         Write-Host "Update completed. You will need to run the script again."
         Start-Sleep 1
         Exit

--- a/SetupCrossTenantRelationshipForTargetTenant.ps1
+++ b/SetupCrossTenantRelationshipForTargetTenant.ps1
@@ -823,9 +823,9 @@ function Verification {
         Copy-Item .\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1 -Destination . | Out-Null
         Start-Sleep 1
         Remove-Item -Path .\XTenantTemp\ -Recurse -Force | Out-Null
-        Write-Host "Proceeding with setup."
+        Write-Host "Update completed. You will need to run the script again."
         Start-Sleep 1
-        Main
+        Exit
     }
 }
 PreValidation

--- a/SetupCrossTenantRelationshipForTargetTenant.ps1
+++ b/SetupCrossTenantRelationshipForTargetTenant.ps1
@@ -817,7 +817,7 @@ function Verification {
         Remove-Item -Path $ScriptDir\XTenantTemp\ -Recurse -Force | Out-Null
         Main
     }
-    elseif ((Get-FileHash $ScriptDir).hash -ne (Get-FileHash $ScriptDir\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {
+    elseif ((Get-FileHash $ScriptDir\SetupCrossTenantRelationshipForTargetTenant.ps1).hash -ne (Get-FileHash $ScriptDir\XTenantTemp\SetupCrossTenantRelationshipForTargetTenant.ps1).hash) {
         Write-Host "`nYou are not using the latest version of the script."`n
         Start-Sleep 1
         Write-Host "`nReplacing the local copy of SetupCrossTenantRelationshipForTargetTenant.ps1 and cleaning up temporary files..."


### PR DESCRIPTION
I didn't like the option of creating a text file on GitHub that was just another thing that needs to be updated and could get missed, meaning someone could still be using an older version of the scripts.

Let me know if this way does not work for everyone.

Also, I fixed the error where you are running the script in a new tenant and have not run Enable-OrganizationCustomization since I hit this issue while I was preparing for my own cross tenant migration and was testing in prod (which is a pain when you have MFA enabled).

If everyone approves of the change for the targettenant setup, I will make the same changes in the other files as well.